### PR TITLE
Fix env selection when env url param is missing

### DIFF
--- a/assets/js/boilerplate.js
+++ b/assets/js/boilerplate.js
@@ -245,7 +245,9 @@ function demonstrationHelper(settings) {
                 ? window.location.search
                 : window.location.hash.replace("#", "?")
             );
-            if (urlParams.get("env").toLowerCase() === "live") {
+
+            const envParam = urlParams.get("env");
+            if (envParam && envParam.toLowerCase() === "live") {
                 isRunningOnSim = false;
             } else if (urlParams.get("state") !== null) {
                 try {


### PR DESCRIPTION
**Issue:**
All samples are broken both when cloning the repo and accessing them from https://saxobank.github.io/openapi-samples-js/

**Fix:**
Env detection logic should also work when env url param is not passed, which is the case for scenarios mentioned in the issue.
